### PR TITLE
ACMS-1208: Fix reported issue on 1.5.x

### DIFF
--- a/acquia_cms_common.install
+++ b/acquia_cms_common.install
@@ -20,7 +20,7 @@ function acquia_cms_common_install() {
     'view media',
   ]);
   
-  // Re-write the content view on module install,
+  // Re-write the content and media view on module install,
   // since we have moved this config in optional directory.
   $module_path = \Drupal::moduleHandler()->getModule('acquia_cms_common')->getPath();
   $config_optional = $module_path . '/config/optional';
@@ -28,6 +28,8 @@ function acquia_cms_common_install() {
 
   $config_storage = \Drupal::service('config.storage');
   $config_storage->write('views.view.content', $source_optional_dir->read('views.view.content'));
+  $config_storage->write('views.view.media', $source_optional_dir->read('views.view.media'));
+  
 }
 
 /**

--- a/acquia_cms_common.install
+++ b/acquia_cms_common.install
@@ -19,6 +19,15 @@ function acquia_cms_common_install() {
     'access content',
     'view media',
   ]);
+  
+  // Re-write the content view on module install,
+  // since we have moved this config in optional directory.
+  $module_path = \Drupal::moduleHandler()->getModule('acquia_cms_common')->getPath();
+  $config_optional = $module_path . '/config/optional';
+  $source_optional_dir = new FileStorage($config_optional);
+
+  $config_storage = \Drupal::service('config.storage');
+  $config_storage->write('views.view.content', $source_optional_dir->read('views.view.content'));
 }
 
 /**


### PR DESCRIPTION
- Fix missing categories and tags filter from content and media page along with below test
`1) Drupal\Tests\acquia_cms\ExistingSite\InstallStateTest::testAdminDashboardTagsCategories
Behat\Mink\Exception\ElementNotFoundException: Form field with id|name|label|value "Categories" not found.`