### PR TITLE
ACMS 1213: Apply Drupal security release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "drupal/checklistapi": "^2.0",
         "drupal/config_ignore": "2.3.0",
         "drupal/config_rewrite": "^1.4",
-        "drupal/core": "~9.2.18 || ~9.3.12",
+        "drupal/core": "~9.2.20 || ~9.3.14",
         "drupal/default_content": "2.0.0-alpha1",
         "drupal/diff": "^1",
         "drupal/entity_clone": "1.0-beta6",


### PR DESCRIPTION
Upgrade Drupal to 9.2.20 || 9.3.14 which fixes security vulnerabilities: https://www.drupal.org/sa-core-2022-010