### PR TITLE
ACMS-1184: Updated the composer json file with latest drupal version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "drupal/checklistapi": "^2.0",
         "drupal/config_ignore": "2.3.0",
         "drupal/config_rewrite": "^1.4",
-        "drupal/core": "~9.2.20 || ~9.3.14",
+        "drupal/core": "~9.4.0",
         "drupal/default_content": "2.0.0-alpha1",
         "drupal/diff": "^1",
         "drupal/entity_clone": "1.0-beta6",
@@ -32,7 +32,6 @@
         "drupal/memcache": "^2.2",
         "drupal/moderation_dashboard": "1.0.0-beta3",
         "drupal/moderation_sidebar": "^1.5",
-        "drupal/mysql56": "^1.0",
         "drupal/password_policy": "^3.0",
         "drupal/pathauto": "^1",
         "drupal/recaptcha": "^3",
@@ -79,7 +78,7 @@
             "drupal/core": {
                 "3059955 - It is possible to overflow the number of items allowed in Media Library": "https://www.drupal.org/files/issues/2019-12-28/3082690-80.patch",
                 "3160238 - Media Library widget produces \"This value should not be null\" error when field is required": "https://www.drupal.org/files/issues/2020-10-08/3160238-25.patch",
-                "3160238 - SQLite database locking errors cause fatal errors": "https://www.drupal.org/files/issues/1120020-59.patch"
+                "1120020 - SQLite database locking errors cause fatal errors": "https://www.drupal.org/files/issues/2022-03-30/1120020-91.patch"
             },
             "drupal/default_content": {
                 "2698425 - Duplicate content issues in default content": "https://git.drupalcode.org/project/default_content/-/merge_requests/5.patch"


### PR DESCRIPTION
## Updated Drupal version to 9.4.0-alpha1 and performed the following checks.

1. Acquia CMS installation w/o SS (Cli & UI) - passed without any errors.
2. Content Creation & Updation. - Passed

Patches changed - "3160238 - SQLite database locking errors cause fatal errors": "https://www.drupal.org/files/issues/1120020-59.patch"
<img width="948" alt="Screenshot 2022-06-11 at 7 00 12 PM" src="https://user-images.githubusercontent.com/15887127/173194906-92b3cfd3-aab0-4198-9943-a1bd7b7140cf.png">

## Question for @vishalkhode1  - 
How should we handle patch for sites that will run on older version - (~9.3.16)