### PR TITLE
ACMS-1256: Creating a drush command for starter kit display.

### DIFF
--- a/acquia_cms_common.module
+++ b/acquia_cms_common.module
@@ -314,16 +314,10 @@ function acquia_cms_common_module_implements_alter(&$implementations, $hook) {
  * Implements hook_preprocess_template().
  */
 function acquia_cms_common_preprocess_status_report_general_info(&$variables) {
-  // List of available starter kits.
-  $starter_kits = [
-    'acquia_cms_enterprise_low_code' => 'Acquia CMS Enterprise Low Code',
-    'acquia_cms_headless' => 'Acquia CMS Headless' ,
-    'acquia_cms_community' => 'Acquia CMS Community',
-  ];
   // Check for the starter kit selection.
-  if ($starter_kit = \Drupal::state()->get('acquia_cms.starter_kit')) {
+  if ($starter_kit = \Drupal::service('acquia_cms_common.utility')->getStarterKit()) {
     // Store selected starter kit into the variable.
-    $variables['acquia_cms']['starter_kit'] = $starter_kits[$starter_kit];
+    $variables['acquia_cms']['starter_kit'] = $starter_kit;
   }
 }
 

--- a/acquia_cms_common.services.yml
+++ b/acquia_cms_common.services.yml
@@ -15,7 +15,7 @@ services:
 
   acquia_cms_common.utility:
     class:  Drupal\acquia_cms_common\Services\AcmsUtilityService
-    arguments: ['@module_handler', '@config.factory']
+    arguments: ['@module_handler', '@config.factory', '@state']
 
   acquia_cms_common.uninstall_validator:
     class: Drupal\acquia_cms_common\AcmsModulesUninstallValidator

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -26,3 +26,8 @@ services:
       - '@acquia_cms_common.utility'
     tags:
       - { name: drush.command }
+
+  acquia_cms_common.acms_status:
+    class: 'Drupal\acquia_cms_common\Commands\AcmsStatus'
+    tags:
+      - { name: drush.command_info_alterer }

--- a/src/Commands/AcmsCommands.php
+++ b/src/Commands/AcmsCommands.php
@@ -2,15 +2,17 @@
 
 namespace Drupal\acquia_cms_common\Commands;
 
+use Drush\Commands\DrushCommands;
+use Drupal\Core\KeyValueStore\KeyValueFactory;
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\CommandError;
-use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
 use Drupal\acquia_cms_common\Services\AcmsUtilityService;
-use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\Core\KeyValueStore\KeyValueFactory;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drush\Commands\DrushCommands;
+use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+use Consolidation\OutputFormatters\StructuredData\PropertyList;
 
 /**
  * A Drush command file.
@@ -243,6 +245,33 @@ class AcmsCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
    */
   public function importSiteStudioPackages() {
     $this->acmsUtilityService->siteStudioPackageImport();
+  }
+
+  /**
+   * Display starter-kit name.
+   *
+   * @command acms:starter-kit
+   * @aliases askt
+   * @usage acms:starter-kit
+   *   Display starter kit value.
+   */
+  public function starterKit($filter = '', $options = ['project' => self::REQ, 'format' => 'table']) {
+    if ($starter_kit = $this->acmsUtilityService->getStarterKit()) {
+      $data['starter-kit'] = $starter_kit;
+      $result = new PropertyList($data);
+      $result->addRendererFunction(
+        function ($key, $cellData, FormatterOptions $options, $rowData) {
+          if ($key == 'first') {
+              return "<comment>$cellData</>";
+          }
+          return $cellData;
+        }
+      );
+
+      return $result;
+    }
+
+    return $this->output()->writeln('Starter-kit is not installed yet.');
   }
 
 }

--- a/src/Commands/AcmsStatus.php
+++ b/src/Commands/AcmsStatus.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\acquia_cms_common\Commands;
+
+use Consolidation\AnnotatedCommand\CommandInfoAltererInterface;
+use Consolidation\AnnotatedCommand\Parser\CommandInfo;
+use Drush\Commands\DrushCommands;
+
+/**
+ * A Drush command file.
+ */
+class AcmsStatus extends DrushCommands implements CommandInfoAltererInterface {
+
+  /**
+   * Altering information for drush status.
+   *
+   * @return string
+   */
+  public function alterCommandInfo(CommandInfo $commandInfo, $commandFileInstance) {
+    if ($commandInfo->getName() === 'extension:status') {
+      $starter_kit = \Drupal::service('acquia_cms_common.utility')->getStarterKit();
+      if(isset($starter_kit)) {
+        echo dt("\n Starter Kit: !starter_kit. \n\n", ['!starter_kit' => $starter_kit]);
+      }
+      else {
+        echo dt("Starter Kit is not installed. \n\n");
+      }
+    }
+  }
+
+}

--- a/src/Services/AcmsUtilityService.php
+++ b/src/Services/AcmsUtilityService.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\acquia_cms_common\Services;
 
+use Drupal\Core\State\StateInterface;
 use Drupal\cohesion\Drush\DX8CommandHelpers;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -26,6 +27,13 @@ class AcmsUtilityService {
   protected $configFactory;
 
   /**
+   * The state service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
    * The module preinstall triggered status.
    *
    * @var string
@@ -47,10 +55,13 @@ class AcmsUtilityService {
    *   The ModuleHandlerInterface.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state service.
    */
-  public function __construct(ModuleHandlerInterface $moduleHandler, ConfigFactoryInterface $config_factory) {
+  public function __construct(ModuleHandlerInterface $moduleHandler, ConfigFactoryInterface $config_factory, StateInterface $state) {
     $this->moduleHandler = $moduleHandler;
     $this->configFactory = $config_factory;
+    $this->state = $state;
   }
 
   /**
@@ -222,6 +233,29 @@ class AcmsUtilityService {
     if (static::$modulePreinstallTriggered !== NULL) {
       return static::$modulePreinstallTriggered;
     }
+    return NULL;
+  }
+
+  /**
+   * Get selected starter-kit.
+   *
+   * @return string|null
+   *   The starter-kit name or null.
+   */
+  public function getStarterKit(): ?string {
+    // List of available starter kits.
+    $starter_kits = [
+      'acquia_cms_enterprise_low_code' => 'Acquia CMS Enterprise Low Code',
+      'acquia_cms_headless' => 'Acquia CMS Headless' ,
+      'acquia_cms_community' => 'Acquia CMS Community',
+    ];
+
+    // Check for the starter kit selection.
+    if ($starter_kit = $this->state->get('acquia_cms.starter_kit')) {
+      // Return starter-kit value.
+      return $starter_kits[$starter_kit];
+    }
+
     return NULL;
   }
 


### PR DESCRIPTION
Created method in a service class for code reusability.
drush askt or drush acms:starter-kit

<img width="442" alt="Screenshot 2022-07-01 at 12 50 27 PM" src="https://user-images.githubusercontent.com/106175376/176844838-b0f154e5-19e8-48d5-998f-e3a7cf449d2b.png">
<img width="522" alt="Screenshot 2022-07-01 at 12 50 48 PM" src="https://user-images.githubusercontent.com/106175376/176844909-0584a5a8-22bd-41b0-9959-4cebc6ea14f4.png">
