### PR TITLE
ACMS-1112: Adding contributed modules patch for fixing php8.1 deprecation.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,6 +96,15 @@
             },
             "drupal/google_analytics": {
                 "3246597 - Add dependency on drupal:path_alias": "https://www.drupal.org/files/issues/2021-11-25/google_analytics-3246597-7.patch"
+            },
+            "drupal/purge": {
+                "3259320 - Fix deprecated php 8.1 errors for drupal:purge": "https://www.drupal.org/files/issues/2022-02-24/3259320-10.patch"
+            },
+            "drupal/reroute_email": {
+                "3275956 - Fix deprecated preg_split() with php 8.1 for drupal:reroute_email": "https://www.drupal.org/files/issues/2022-04-19/reroute_email-preg_split--3275956-1.patch"
+            },
+            "guzzlehttp/guzzle": {
+                "GuzzleHttp deprecation fix with PHP 8.1 support": "https://gist.githubusercontent.com/alpha1892/a6f283f354c15fba03a47454b08c3b10/raw/11e188f94e8e57c31fc2cf401d2a8c6757fada72/guzzle-cookie-cookiejar-deprecation.patch"
             }
         }
     },


### PR DESCRIPTION
Patches#
drupal/purge: https://www.drupal.org/files/issues/2022-02-24/3259320-10.patch
drupal/reroute_email: https://www.drupal.org/files/issues/2022-04-19/reroute_email-preg_split--3275956-1.patch